### PR TITLE
fix: link to discord

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@ Welcome to ROS Embodied AI Community Group! Please refer to our [living document
 
 For communication with the group, join the discord server:
 
-[![](https://dcbadge.limes.pink/api/server/https://discord.gg/n2znP3BjCf)](https://discord.gg/n2znP3BjCf)
+[![](https://dcbadge.limes.pink/api/server/https://discord.gg/3PGHgTaJSB)](https://discord.gg/3PGHgTaJSB)
 
 ## Goal
 


### PR DESCRIPTION
link added in https://github.com/ros-wg-embodied-ai/.github/pull/3 got outdated . This PR adds a new link. 